### PR TITLE
Fix: Add missing axios dependency to package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "description": "",
   "dependencies": {
     "@azure/msal-node": "^2.16.2",
+    "axios": "^1.3.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION

### Summary
This pull request addresses the issue where the `axios` module was missing from the `package.json` dependencies, causing the backend to throw a `Cannot find package 'axios'` error. This update adds `axios` as a dependency to ensure proper HTTP request handling in the `routes/gmail.js` file.

### Changes Made
- Added `axios` version `^1.3.0` to the `dependencies` section of `package.json`.

### Impact
- This resolves the error in the `gmail.js` route where the `axios` module was required but not found, allowing the backend server to make HTTP requests to the classification service.

### Related Issue
Resolves #4: Missing `axios` dependency causing errors during runtime.

### Testing
- Verified that the backend server starts without errors after the addition of `axios`.
- Confirmed that the email classification process works as expected, making use of `axios` to send requests.

Please review and merge to resolve the issue.