### PR TITLE
Fix: Add requirements.txt for backend dependencies

### DIFF
--- a/backend/classifier/requirements.txt
+++ b/backend/classifier/requirements.txt
@@ -1,0 +1,6 @@
+beautifulsoup4==4.12.3
+firebase_admin==6.6.0
+Flask==3.1.0
+flask_cors==5.0.0
+joblib==1.4.2
+scikit_learn==1.6.0


### PR DESCRIPTION

This PR adds a `requirements.txt` file to the `backend` directory of the monorepo, listing all the necessary Python dependencies for the classifier to run.  

**Changes made:**  
- Added `requirements.txt` containing the following dependencies:  
  ```plaintext
  beautifulsoup4==4.12.3  
  firebase_admin==6.6.0  
  Flask==3.1.0  
  flask_cors==5.0.0  
  joblib==1.4.2  
  scikit_learn==1.6.0  
  ```  

**Purpose:**  
This ensures that the environment can be easily set up using `pip install -r requirements.txt`, resolving issues with missing dependencies previously reported in #7.

**Resolves #7.**