### PR TITLE
fix: revert to managing processes directly in run.ps1 to resolve issue #14

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,16 +6,12 @@
             "type": "shell",
             "command": "python",
             "args": ["svm_model.py"],
-            "group": {
-                "kind": "build",
-                "isDefault": true
+            "options": {
+                "cwd": "${workspaceFolder}/backend/classifier"
             },
             "presentation": {
                 "reveal": "always",
                 "panel": "new"
-            },
-            "options": {
-                "cwd": "${workspaceFolder}/backend/classifier"
             }
         },
         {
@@ -23,12 +19,12 @@
             "type": "shell",
             "command": "node",
             "args": ["server.js"],
+            "options": {
+                "cwd": "${workspaceFolder}/backend"
+            },
             "presentation": {
                 "reveal": "always",
                 "panel": "new"
-            },
-            "options": {
-                "cwd": "${workspaceFolder}/backend"
             }
         },
         {
@@ -36,13 +32,21 @@
             "type": "shell",
             "command": "npm",
             "args": ["start"],
+            "options": {
+                "cwd": "${workspaceFolder}/frontend"
+            },
             "presentation": {
                 "reveal": "always",
                 "panel": "new"
-            },
-            "options": {
-                "cwd": "${workspaceFolder}/frontend"
             }
+        },
+        {
+            "label": "Run All",
+            "dependsOn": [
+                "Start Python SVM Model",
+                "Start Node.js Backend",
+                "Start React Frontend"
+            ]
         }
     ]
 }

--- a/run.ps1
+++ b/run.ps1
@@ -1,11 +1,43 @@
 # run.ps1
 
-Write-Host "Running tasks in VS Code..."
+# Function to stop all running processes for the project
+function Stop-AllProcesses {
+    Write-Host "Stopping all processes..."
+    $processes = Get-Process | Where-Object { $_.Name -in @("python", "node") }
+    if ($processes) {
+        $processes | Stop-Process -Force
+        Write-Host "All processes stopped successfully."
+    } else {
+        Write-Host "No matching processes found to stop."
+    }
+}
 
-# Use the VS Code CLI to start the tasks.json tasks
-code --reuse-window --add .
-code --execute-task "Start Python SVM Model"
-code --execute-task "Start Node.js Backend"
-code --execute-task "Start React Frontend"
+# Register a cleanup event to stop processes when the script exits
+$script:ExitHandler = {
+    Stop-AllProcesses
+}
+Register-EngineEvent PowerShell.Exiting -Action $script:ExitHandler
 
-Write-Host "All tasks started successfully!"
+# Helper function to run a process and keep the window open upon error or exit
+function Start-ProcessWithWindow {
+    param (
+        [string]$Path,
+        [string]$Arguments,
+        [string]$WorkingDirectory
+    )
+    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd '$WorkingDirectory'; $Path $Arguments"
+}
+
+# Start Python process
+Write-Host "Starting SVM Model..."
+Start-ProcessWithWindow -Path "python" -Arguments "svm_model.py" -WorkingDirectory "./backend/classifier"
+
+# Start Node.js backend
+Write-Host "Starting Backend Server..."
+Start-ProcessWithWindow -Path "node" -Arguments "server.js" -WorkingDirectory "./backend"
+
+# Start React frontend
+Write-Host "Starting Frontend..."
+Start-ProcessWithWindow -Path "npm" -Arguments "start" -WorkingDirectory "./frontend"
+
+Write-Host "All processes have been started successfully!"


### PR DESCRIPTION
This PR reverts the changes made in PR #16 and restores the previous functionality of the `run.ps1` script to directly manage processes. The script now starts the SVM model, Node.js backend, and React frontend in separate windows, ensuring proper process management during startup.

Changes include:
- Reverting from VS Code task execution to direct process management.
- Ensuring that each process runs in a separate PowerShell window for easier troubleshooting.

This update resolves issue #14, which was reopened due to issues with the VS Code task execution approach.

Closes #14
