### PR TITLE
Add --verbose parameter to npm module installation commands

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -37,10 +37,10 @@ if ($Service -eq "install" -or $Service -eq "all") {
     Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './backend/classifier'; pip install -r requirements.txt"
 
     Write-Host "Installing Node.js dependencies for backend..."
-    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './backend'; npm install"
+    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './backend'; npm install --verbose"
 
     Write-Host "Installing Node.js dependencies for frontend..."
-    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './frontend'; npm install"
+    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './frontend'; npm install --verbose"
 }
 
 # Start services based on the parameter


### PR DESCRIPTION
`--verbose` allows a debugger to know whether the process to `npm install` is still running or stuck and take appropriate action.
