### PR TITLE
Add --legacy-peer-deps and --force options to run scripts and set LPD as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,6 @@ install:
 	@echo "Installing Python dependencies..."
 	pip install -r backend/classifier/requirements.txt
 	@echo "Installing Node.js dependencies for backend..."
-	cd backend && npm install
+	cd backend && npm install --legacy-peer-deps
 	@echo "Installing Node.js dependencies for frontend..."
-	cd frontend && npm install
+	cd frontend && npm install --legacy-peer-deps

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,9 @@
     "start": "set HTTPS=true&&set PORT=5002&&set SSL_CRT_FILE=ssl/localhost-cert.pem&&set SSL_KEY_FILE=ssl/localhost-key.pem&&react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "install:force": "npm install --force",
+    "install:legacy": "npm install --legacy-peer-deps"
   },
   "eslintConfig": {
     "extends": [

--- a/run.ps1
+++ b/run.ps1
@@ -37,10 +37,10 @@ if ($Service -eq "install" -or $Service -eq "all") {
     Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './backend/classifier'; pip install -r requirements.txt"
 
     Write-Host "Installing Node.js dependencies for backend..."
-    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './backend'; npm install --verbose"
+    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './backend'; npm install --legacy-peer-deps"
 
     Write-Host "Installing Node.js dependencies for frontend..."
-    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './frontend'; npm install --verbose"
+    Start-Process -FilePath "powershell" -ArgumentList "-NoExit", "-Command", "cd './frontend'; npm install --legacy-peer-deps"
 }
 
 # Start services based on the parameter

--- a/start_services.sh
+++ b/start_services.sh
@@ -7,7 +7,7 @@ tmux new-session -d -s services "python backend/classifier/svm_model.py"
 tmux split-window -h "node backend/server.js"
 
 # Split the window vertically and start the frontend
-tmux split-window -v "cd frontend && npm start"
+tmux split-window -v "cd frontend && npm install --legacy-peer-deps && npm start"
 
 # Select the first pane
 tmux select-pane -t 0


### PR DESCRIPTION
This PR enhances the project's installation and run scripts by addressing dependency resolution issues commonly encountered during `npm install`. Key updates include:

- **Added `--legacy-peer-deps` as Default**:
  - Updated all relevant scripts (Makefile, run.ps1, start_services.sh) to use the `--legacy-peer-deps` flag for Node.js dependency installation.
  - Ensures smoother installation of dependencies by bypassing strict peer dependency checks.

- **Introduced `--force` Option**:
  - Added a custom `install:force` script in package.json for cases where `--force` is required to resolve dependency conflicts.

- **Improved Cross-Platform Compatibility**:
  - Ensured that all installation scripts across different environments (Makefile, PowerShell, Bash) are consistent and robust.

### Benefits:
- Resolves dependency conflicts during installation, particularly for packages like `i18next` and `react-i18next`.
- Provides flexibility for developers to choose between `--legacy-peer-deps` and `--force` as needed.
- Enhances the developer experience by reducing manual intervention during setup.

### Usage:
1. **Default Installation**:
   - Run the following commands to install dependencies with `--legacy-peer-deps`:
     ```bash
     make install
     ```
     or
     ```powershell
     ./run.ps1 -Service install
     ```

2. **Force Installation**:
   - Use the `install:force` script for cases requiring `--force`:
     ```bash
     npm run install:force
     ```

This update ensures a more seamless setup process for all developers working on the project.